### PR TITLE
#65: Überlappung von Straßennamen verhindern

### DIFF
--- a/packages/OpenSqueakMap.package/OSMChunk.class/instance/zoomlevelAbstraction.st
+++ b/packages/OpenSqueakMap.package/OSMChunk.class/instance/zoomlevelAbstraction.st
@@ -7,7 +7,7 @@ zoomlevelAbstraction
 		16 . (Set new add: 'motorway'; add: 'trunk'; add: 'primary'; add: 'secondary'; add: 'tertiary'; yourself) .
 		17 . (Set new add: 'motorway'; add: 'trunk'; add: 'primary'; add: 'secondary'; add: 'tertiary'; add: 'residential'; yourself) .
 		18 . (Set new add: 'motorway'; add: 'trunk'; add: 'primary'; add: 'secondary'; add: 'tertiary'; add: 'residential';
-							  add: 'cycleway'; add: 'track'; yourself) .
+							  add: 'cycleway'; add: 'track'; add: 'service'; add: 'path'; add: 'footway'; yourself) .
 		19 . (Set new add: 'motorway'; add: 'trunk'; add: 'primary'; add: 'secondary'; add: 'tertiary'; add: 'residential'; 
 							  add: 'cycleway'; add: 'track'; add: 'service'; add: 'path'; add: 'footway'; yourself).
 		20 . (Set new add: 'motorway'; add: 'trunk'; add: 'primary'; add: 'secondary'; add: 'tertiary'; add: 'residential'; 

--- a/packages/OpenSqueakMap.package/OSMChunk.class/methodProperties.json
+++ b/packages/OpenSqueakMap.package/OSMChunk.class/methodProperties.json
@@ -41,5 +41,5 @@
 		"viewport:" : "PB 7/29/2016 10:31",
 		"wayMorphs" : "PB 7/29/2016 10:24",
 		"wayMorphs:" : "PB 7/29/2016 10:32",
-		"zoomlevelAbstraction" : "jz 6/11/2017 12:15",
+		"zoomlevelAbstraction" : "bk 7/6/2017 20:23",
 		"zoomlevelAbstraction:" : "jz 6/8/2017 15:28" } }

--- a/packages/OpenSqueakMap.package/OSMRenderObject.class/instance/showStreetName..st
+++ b/packages/OpenSqueakMap.package/OSMRenderObject.class/instance/showStreetName..st
@@ -1,24 +1,29 @@
 morphic
 showStreetName: aSet
-	| streetType deltaX deltaY |
+	| streetType streetLength deltaX deltaY |
 	"#highway is key for different street types"
 	streetType := (self tags at: #highway ifAbsent: ['']).
 	(aSet detect: [:aStreetType | aStreetType = streetType] ifNone: []) ifNotNil: [
 		self displayedName
 			ifNotNil: [
 				self displayedName owner delete].
-		self displayedName: (self tags at: #name ifAbsent: ['']) asStringMorph.
-		self owner addMorphFront: self displayedName.
+		streetLength := self totalLength.
+		streetLength > 200
+			ifTrue: [self displayedName: (self tags at: #name ifAbsent: ['']) asStringMorph.
+					self owner addMorphFront: self displayedName.
 		
-		deltaX := self firstVertex x -  self lastVertex x.
-		deltaY := self firstVertex y -  self lastVertex y.
-		deltaX < 0 ifTrue:
-			[deltaX := deltaX negated.
-			deltaY := deltaY negated].
+					deltaX := self firstVertex x -  self lastVertex x.
+					deltaY := self firstVertex y -  self lastVertex y.
+					deltaX < 0 ifTrue:
+						[deltaX := deltaX negated.
+						deltaY := deltaY negated].
+					
+					self displayedName
+						fontName: 'Bitmap DejaVu Sans' size: 16;
+						position: self midpoint - ((self displayedName width / 2) @ (self displayedName height / 2));
+						rotationDegrees: (deltaY arcTan: deltaX) * 180 / Float pi]].
+	
+			
 		
-		self displayedName
-			fontName: 'BitstreamVeraSans' size: 20;
-			position: self midpoint - ((self displayedName width / 2) @ (self displayedName height / 2));
-			rotationDegrees: (deltaY arcTan: deltaX) * 180 / Float pi].
 		
 		

--- a/packages/OpenSqueakMap.package/OSMRenderObject.class/methodProperties.json
+++ b/packages/OpenSqueakMap.package/OSMRenderObject.class/methodProperties.json
@@ -33,7 +33,7 @@
 		"setRenderAttributes" : "lh 6/3/2017 14:42",
 		"setRenderAttributesWithVertices:" : "bk 6/28/2017 23:39",
 		"shouldShowAt:" : "lh 6/3/2017 14:18",
-		"showStreetName:" : "lh 7/5/2017 17:55",
+		"showStreetName:" : "bk 7/6/2017 20:21",
 		"tags" : "PB 7/29/2016 11:00",
 		"toggleMarker" : "lh 6/15/2017 11:59",
 		"type" : "PB 7/29/2016 10:57",


### PR DESCRIPTION
Fixes #65 

<img width="220" alt="bildschirmfoto 2017-07-06 um 20 26 37" src="https://user-images.githubusercontent.com/807665/27927096-f41fa750-628a-11e7-94e3-1ad4d534c70a.png"><img width="220" alt="bildschirmfoto 2017-07-06 um 20 26 41" src="https://user-images.githubusercontent.com/807665/27927097-f439c450-628a-11e7-84b0-a81d5d0cc79c.png"><img width="220" alt="bildschirmfoto 2017-07-06 um 20 26 45" src="https://user-images.githubusercontent.com/807665/27927099-f445de98-628a-11e7-83f4-8a55a3a8d1cf.png"><img width="220" alt="bildschirmfoto 2017-07-06 um 20 26 48" src="https://user-images.githubusercontent.com/807665/27927100-f4464838-628a-11e7-9e4e-397b46d5223e.png"><img width="220" alt="bildschirmfoto 2017-07-06 um 20 26 52" src="https://user-images.githubusercontent.com/807665/27927101-f449429a-628a-11e7-8541-6afdfa413ed7.png">
